### PR TITLE
Fixed the issue with not being able to pick GCPs

### DIFF
--- a/moniQue/gui/dlg_main.py
+++ b/moniQue/gui/dlg_main.py
@@ -405,6 +405,7 @@ class MainDialog(QtWidgets.QDialog):
                 
             else:
                 mesh_material = gfx.MeshNormalMaterial(side="FRONT")
+                mesh_material.pick_write = True
                 
         # mesh_material = gfx.MeshPhongMaterial(color="#BEBEBE", side="FRONT", shininess=10)
 


### PR DESCRIPTION
in the object canvas when running the Plugin with
pygfx version 0.2.0 or higher. Issue occured
because of API changes in v0.2.0 where picking
needs to be enabled manually. Solution (Line 408): mesh_material.pick_write = True